### PR TITLE
fix: web 后端始终关闭标签，不再泄漏 tab

### DIFF
--- a/chatgpt-imagegen
+++ b/chatgpt-imagegen
@@ -721,20 +721,23 @@ def run_web(args: argparse.Namespace, progress: bool, start: float) -> tuple[byt
             time.sleep(1.0)
         return False
 
+    def _close() -> None:
+        """Close the session's browser/tab. Best-effort; never raises."""
+        try:
+            _ab(ab, "close", session=session, timeout=15.0)
+        except Exception:
+            pass  # leftover tab is harmless; never fail the run over cleanup
+
     chosen: str | None = None
     opened = False
-    for i, prof in enumerate(candidates):
+    for prof in candidates:
         label = "current Chrome (relay)" if prof is None else f"profile {prof!r}"
         emit(f"opening ChatGPT via {label}")
         if _try_open(prof):
             chosen, opened = prof, True
             emit(f"using {label}")
             break
-        if i < len(candidates) - 1:
-            try:  # clean up the non-logged-in attempt before trying the next
-                _ab(ab, "close", session=session, timeout=10.0)
-            except GatewayError:
-                pass
+        _close()  # always tear down a failed attempt, including the last
     if not opened:
         raise WebUnavailable(
             "no logged-in ChatGPT browser available (tried the open Chrome"
@@ -742,9 +745,20 @@ def run_web(args: argparse.Namespace, progress: bool, start: float) -> tuple[byt
             + "). Sign in to chatgpt.com, or use --backend codex."
         )
 
+    # Everything past here drives the now-open browser. Wrap it so the tab is
+    # ALWAYS closed on the way out — success, failure (quota/refusal/timeout), or
+    # exception — instead of leaking a window on every non-happy path.
+    try:
+        return _generate_in_browser(
+            ab, session, user_text, args, deadline, remaining, emit)
+    finally:
+        if not args.keep_tab:
+            _close()
+
+
+def _generate_in_browser(ab, session, user_text, args, deadline, remaining, emit):
     # Capture the baseline set of image srcs already on the page so we never
     # mistake a prior image for the new one.
-
     baseline = _ab_eval(ab, _JS_BASELINE % json.dumps(WEB_IMG_SRC_RE),
                         session=session, timeout=min(20.0, remaining()))
     if not isinstance(baseline, list):
@@ -845,11 +859,8 @@ def run_web(args: argparse.Namespace, progress: bool, start: float) -> tuple[byt
         raise GatewayError("generated image came back as invalid base64") from None
 
     meta: JsonDict = {"content_type": res.get("type"), "source": "web"}
-    if not args.keep_tab:
-        try:
-            _ab(ab, "close", session=session, timeout=15.0)
-        except GatewayError:
-            pass  # leaving a tab open is harmless; never fail the run over cleanup
+    # Cleanup (closing the tab) is handled by run_web's finally, so it runs on
+    # every exit path — not just this success one.
     return image_bytes, meta
 
 


### PR DESCRIPTION
## 问题
web 后端"用完不清理":`run_web` 只在**成功路径**末尾 `close`,任何失败(配额用尽、模型拒绝、超时、异常)都会留下打开的 ChatGPT 标签。今天反复失败 → 攒了一堆 tab(`close --all` 扫出了真实遗留会话 `imagegen-9293`)。

## 修复
把"打开浏览器之后"的全部流程(baseline→提交→轮询→下载)抽进 `_generate_in_browser`,在 `run_web` 里用 **try/finally** 包起来:无论成功、失败还是异常,只要没设 `--keep-tab` 就**一定** `close`。候选循环里失败的尝试也改成每次都关(含最后一个)。

## 验证
- ✅ 失败路径(配额)运行后 Chrome 进程数回到基线,无泄漏
- ✅ 成功路径实测真出了一张图(`--profile "Profile 3"` 生成 teal pentagon),tab 正常关闭
- ✅ `agent-browser close --all` 清掉了旧代码遗留的会话

纯 web 后端清理修复,无行为/接口变化。