### PR TITLE
feat(web): 模型档位候选列表 + 纯函数单测

### DIFF
--- a/chatgpt-imagegen
+++ b/chatgpt-imagegen
@@ -116,7 +116,10 @@ WEB_IMG_SRC_RE = r"estuary/content|files/download|oaiusercontent"
 # yields a native image asset and detection times out. "Instant" generates
 # natively. The picker is sticky per browser, so a Chrome left on Pro poisons
 # every web run until we switch it. Override via CHATGPT_IMAGEGEN_WEB_MODEL.
-WEB_MODEL_DEFAULT = "Instant"
+# Comma-separated CANDIDATES tried in order — the first that exists in the picker
+# wins — because plans label the image-capable tier differently (Plus/Pro:
+# "Instant"; others may only have "Auto").
+WEB_MODEL_DEFAULT = "Instant,Auto"
 
 JsonDict = dict[str, Any]
 
@@ -1099,35 +1102,47 @@ _JS_MENU_ITEM = r"""(() => {
 
 
 def _ensure_web_model(ab, session, model_label, remaining, emit) -> None:
-    """Switch the ChatGPT composer to ``model_label`` (e.g. "Instant").
+    """Switch the composer to the first available of ``model_label`` (a
+    comma-separated candidate list, e.g. "Instant,Auto").
 
     Needed because "Pro" has no native image generator (see WEB_MODEL_DEFAULT).
-    The menu renders in a React portal that ignores synthetic ``.click()`` and
-    re-renders away injected ids, so we drive it by real coordinate clicks read
-    fresh from getBoundingClientRect each step.
+    Different plans label the image-capable tier differently (Plus/Pro expose
+    Instant/Medium/…; other plans an "Auto"), so we try a list and take the first
+    that exists in the picker — more robust than one hardcoded label. The menu
+    renders in a React portal that ignores synthetic ``.click()`` and re-renders
+    away injected ids, so we drive it by real coordinate clicks read fresh from
+    getBoundingClientRect each step.
 
     Best-effort: on any failure this warns and proceeds with the current model,
     exactly like _enter_project — selection is a nicety, not worth aborting over.
     """
-    if not model_label:
+    candidates = [c.strip() for c in (model_label or "").split(",") if c.strip()]
+    if not candidates:
         return
-    want = model_label.strip().lower()
+    wants = [c.lower() for c in candidates]
     try:
         btn = _ab_eval(ab, _JS_MODEL_BTN, session=session,
                        timeout=min(15.0, remaining()))
         if not isinstance(btn, dict):
             emit("warning: model picker not found; leaving model as-is")
             return
-        if btn.get("text", "").strip().lower().startswith(want):
-            return  # already on the wanted model (picker is sticky)
-        emit(f"switching model {btn.get('text')!r} → {model_label!r}")
+        cur_text = btn.get("text", "").strip().lower()
+        if any(cur_text.startswith(w) for w in wants):
+            return  # already on an acceptable model (picker is sticky)
+        emit(f"switching model {btn.get('text')!r} → first of {candidates}")
         _ab(ab, "click", str(btn["x"]), str(btn["y"]),
             session=session, timeout=min(15.0, remaining()))
         time.sleep(0.6)
-        item = _ab_eval(ab, _JS_MENU_ITEM % json.dumps(model_label),
-                        session=session, timeout=min(15.0, remaining()))
-        if not isinstance(item, dict):
-            emit(f"warning: model {model_label!r} not in the picker; leaving as-is")
+        chosen = None
+        item = None
+        for cand in candidates:  # first candidate present in the open menu wins
+            it = _ab_eval(ab, _JS_MENU_ITEM % json.dumps(cand),
+                          session=session, timeout=min(15.0, remaining()))
+            if isinstance(it, dict):
+                chosen, item = cand, it
+                break
+        if item is None:
+            emit(f"warning: none of {candidates} in the picker; leaving as-is")
             try:  # close the menu so it can't swallow the prompt
                 _ab(ab, "press", "Escape", session=session,
                     timeout=min(10.0, remaining()))
@@ -1140,8 +1155,8 @@ def _ensure_web_model(ab, session, model_label, remaining, emit) -> None:
         now = _ab_eval(ab, _JS_MODEL_BTN, session=session,
                        timeout=min(15.0, remaining()))
         cur = now.get("text") if isinstance(now, dict) else None
-        if isinstance(cur, str) and cur.strip().lower().startswith(want):
-            emit(f"model set to {model_label!r}")
+        if isinstance(cur, str) and cur.strip().lower().startswith(chosen.lower()):
+            emit(f"model set to {chosen!r}")
         else:
             emit(f"warning: model may not have switched (now {cur!r})")
     except WebRateLimited:
@@ -1821,9 +1836,10 @@ def main() -> int:
     parser.add_argument(
         "--web-model",
         default=os.environ.get("CHATGPT_IMAGEGEN_WEB_MODEL", WEB_MODEL_DEFAULT),
-        help="(web backend) composer model/effort to select before generating "
-             f"(default: {WEB_MODEL_DEFAULT!r}; also settable via "
-             "CHATGPT_IMAGEGEN_WEB_MODEL). Must match a picker label exactly. "
+        help="(web backend) composer model/effort to select before generating — "
+             "a comma-separated candidate list, first one present in the picker "
+             f"wins (default: {WEB_MODEL_DEFAULT!r}; also settable via "
+             "CHATGPT_IMAGEGEN_WEB_MODEL). Labels must match the picker exactly. "
              "The 'Pro' tier has no native image generator, so leaving it on Pro "
              "makes the page write Python instead of an image — hence the switch. "
              "Pass an empty string to keep whatever model is already selected.",

--- a/test_chatgpt_imagegen.py
+++ b/test_chatgpt_imagegen.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Unit tests for chatgpt-imagegen's pure helpers — stdlib `unittest`, no deps.
+
+The CLI ships as a single extension-less script, so we load it as a module via
+the SourceFileLoader trick. These cover the browser-free logic (MIME sniffing,
+version parsing, prompt building, path defaults, token extraction, the capped
+ref download) so a refactor that breaks them fails loudly.
+
+Run:  python3 -m unittest test_chatgpt_imagegen -v
+"""
+
+import importlib.machinery
+import importlib.util
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+_loader = importlib.machinery.SourceFileLoader(
+    "cig", os.path.join(os.path.dirname(__file__), "chatgpt-imagegen"))
+_spec = importlib.util.spec_from_loader("cig", _loader)
+cig = importlib.util.module_from_spec(_spec)
+_loader.exec_module(cig)
+
+
+@contextmanager
+def _in_tmp_cwd():
+    prev = os.getcwd()
+    with tempfile.TemporaryDirectory() as d:
+        os.chdir(d)
+        try:
+            yield Path(d)
+        finally:
+            os.chdir(prev)
+
+
+class SniffMime(unittest.TestCase):
+    def test_png(self):
+        self.assertEqual(cig._sniff_mime(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8), "image/png")
+
+    def test_jpeg(self):
+        self.assertEqual(cig._sniff_mime(b"\xff\xd8\xff" + b"\x00" * 8), "image/jpeg")
+
+    def test_webp(self):
+        self.assertEqual(cig._sniff_mime(b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP"), "image/webp")
+
+    def test_unknown(self):
+        self.assertIsNone(cig._sniff_mime(b"not an image at all"))
+
+
+class VersionTuple(unittest.TestCase):
+    def test_parses(self):
+        self.assertEqual(cig._version_tuple("1.5.23"), (1, 5, 23))
+        self.assertEqual(cig._version_tuple("chrome-use 1.5.23"), (1, 5, 23))
+
+    def test_ordering(self):
+        self.assertLess(cig._version_tuple("1.4.9"), cig._version_tuple("1.5.0"))
+        self.assertLess(cig._version_tuple("1.5.0"), cig._version_tuple("1.5.23"))
+
+    def test_junk(self):
+        self.assertEqual(cig._version_tuple("garbage"), (0,))
+
+    def test_min_floor(self):
+        self.assertGreaterEqual(cig._version_tuple("1.5.23"),
+                                cig._version_tuple(cig.AB_MIN_VERSION))
+        self.assertLess(cig._version_tuple("1.4.0"),
+                        cig._version_tuple(cig.AB_MIN_VERSION))
+
+
+class IsUrl(unittest.TestCase):
+    def test_true(self):
+        self.assertTrue(cig._is_url("http://x.com/a.png"))
+        self.assertTrue(cig._is_url("https://x.com/a.png"))
+
+    def test_false(self):
+        self.assertFalse(cig._is_url("/local/a.png"))
+        self.assertFalse(cig._is_url("a.png"))
+        self.assertFalse(cig._is_url("ftp://x.com/a.png"))
+
+
+class BuildWebText(unittest.TestCase):
+    def test_plain_has_no_codex_tool_wording(self):
+        t = cig._build_web_text("a red apple", "auto")
+        self.assertIn("a red apple", t)
+        self.assertNotIn("image_generation tool", t)
+        self.assertNotIn("Output format", t)
+
+    def test_size_folded_in(self):
+        self.assertIn("1024x1536", cig._build_web_text("x", "1024x1536"))
+        self.assertNotIn("auto", cig._build_web_text("x", "auto").lower())
+
+    def test_edit_anchors_on_reference(self):
+        t = cig._build_web_text("make it blue", "auto", is_edit=True)
+        self.assertIn("attached", t.lower())
+
+
+class BuildUserText(unittest.TestCase):
+    def test_codex_keeps_tool_wording(self):
+        t = cig._build_user_text("a cat", "auto", "png")
+        self.assertIn("image_generation tool", t)
+        self.assertIn("png", t)
+
+
+class DefaultOutPath(unittest.TestCase):
+    def test_slugifies_and_numbers(self):
+        with _in_tmp_cwd():
+            p1 = cig._default_out_path("A Red Apple!!", "png")
+            self.assertEqual(p1, Path("assets/generated/a-red-apple.png"))
+            p1.parent.mkdir(parents=True, exist_ok=True)
+            p1.write_bytes(b"x")
+            p2 = cig._default_out_path("A Red Apple!!", "png")
+            self.assertEqual(p2.name, "a-red-apple-2.png")
+
+    def test_empty_prompt_fallback(self):
+        with _in_tmp_cwd():
+            self.assertEqual(cig._default_out_path("!!!", "webp").name, "image.webp")
+
+
+class ExtractAccessToken(unittest.TestCase):
+    def test_reads_nested_tokens(self):
+        auth = {"tokens": {"access_token": "AAA", "account_id": "acc",
+                           "refresh_token": "RRR"}}
+        access, account, refresh = cig._extract_access_token(auth)
+        self.assertEqual((access, refresh), ("AAA", "RRR"))
+
+    def test_missing(self):
+        access, _account, _refresh = cig._extract_access_token({})
+        self.assertIsNone(access)
+
+
+class DownloadRefCap(unittest.TestCase):
+    @contextmanager
+    def _fake_urlopen(self, body: bytes):
+        import urllib.request
+        real = urllib.request.urlopen
+
+        class _Resp:
+            def __enter__(self_):
+                return self_
+
+            def __exit__(self_, *a):
+                return False
+
+            def read(self_, n=-1):
+                return body[:n] if n and n > 0 else body
+
+        urllib.request.urlopen = lambda *a, **k: _Resp()
+        try:
+            yield
+        finally:
+            urllib.request.urlopen = real
+
+    def test_small_ok(self):
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        with self._fake_urlopen(png):
+            self.assertEqual(cig._download_ref_url("https://x/a.png"), png)
+
+    def test_over_cap_exits(self):
+        big = b"\x00" * (cig.REF_DOWNLOAD_MAX + 10)
+        with self._fake_urlopen(big):
+            with self.assertRaises(SystemExit):
+                cig._download_ref_url("https://x/huge.png")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
两项优化（项目优化盘点的剩余项）：

1. **模型档位候选列表** — `--web-model` 现接受逗号分隔候选，按序取第一个在选择器里存在的档位。不同套餐对"能出图的档位"叫法不同（Plus/Pro 是 `Instant`，别的可能只有 `Auto`），单一硬编码会在那些账号切不动。默认改为 `Instant,Auto`；账号已在某候选档位时走快路径直接返回，无额外开销。
2. **新增单测** `test_chatgpt_imagegen.py` — stdlib `unittest`（零依赖，契合单文件理念），覆盖 `_sniff_mime` / `_version_tuple` / `_is_url` / `_build_web_text` / `_build_user_text` / `_default_out_path` / `_extract_access_token` / `_download_ref_url`（含 25MB 上限）。20 个用例全过。

```
python3 -m unittest test_chatgpt_imagegen -v   # Ran 20 tests OK
```
