### PR TITLE
feat(web): 出图后默认删除对话，不留历史（可配置）

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The same subscription meters two separate buckets, and which one you spend depen
 
 | Backend | How it generates | Bucket spent | Needs |
 | --- | --- | --- | --- |
-| **`web`** | Drives your already-logged-in ChatGPT **browser** (via [`chrome-use`](https://github.com/leeguooooo/chrome-use), formerly `agent-browser-stealth`) and generates in a normal chat — the same surface as typing in the app. Its real-Chrome connect clears Cloudflare + the sentinel proof-of-work a plain/headless client can't. Each run's chat is filed under a ChatGPT **Project** (default `imagegen`, created on first use) so it doesn't litter your history. | **ChatGPT conversation** — does *not* touch your metered **Codex-usage** limit. | Any logged-in chatgpt.com browser (**free tier works**) + `chrome-use`. |
+| **`web`** | Drives your already-logged-in ChatGPT **browser** (via [`chrome-use`](https://github.com/leeguooooo/chrome-use), formerly `agent-browser-stealth`) and generates in a normal chat — the same surface as typing in the app. Its real-Chrome connect produces the **Cloudflare Turnstile** token a plain/headless client can't forge (CF's edge and the sentinel PoW are passable bare — Turnstile is the wall). Each run is filed under a ChatGPT **Project** (default `imagegen`) and the conversation is **deleted afterwards by default** (`--keep-conversation` to keep it), so it leaves no history. | **ChatGPT conversation** — does *not* touch your metered **Codex-usage** limit. | Any logged-in chatgpt.com browser (**free tier works**) + `chrome-use`. |
 | **`codex`** | Headless POST to `backend-api/codex/responses`, reusing `~/.codex/auth.json`. | **Codex-usage** (the metered bucket). | `codex login`. |
 
 **Default `auto`** tries `web` first (to spare Codex-usage) and falls back to `codex` when no logged-in browser is reachable. Force one with `--backend web` / `--backend codex` (or `CHATGPT_IMAGEGEN_BACKEND`).
@@ -103,10 +103,11 @@ chatgpt-imagegen "<prompt>" [options]
 | --- | --- | --- |
 | `--backend` | `auto` | `auto` \| `web` \| `codex`. `auto` prefers web (spares Codex-usage), falls back to codex if no logged-in browser. See [Backends](#backends). Also `CHATGPT_IMAGEGEN_BACKEND`. |
 | `--profile` | `auto` | *(web)* Which Chrome profile to drive. `auto`: use your open Chrome if it's logged in, else auto-switch to a profile that is (detected offline). `relay`: only your open Chrome. Or a name like `"Profile 3"`. |
-| `--session` | `imagegen-<pid>` | *(web)* Reuse a named `chrome-use` Chrome tab group across runs. |
+| `--session` | `imagegen` | *(web)* Named `chrome-use` Chrome tab group reused across runs (one stable daemon instead of one per run). Falls back to `imagegen-<pid>` when web concurrency is raised above 1, to isolate parallel runs. |
 | `--project` | `imagegen` | *(web)* ChatGPT Project to file the conversation under — matched by exact name, **created on first use**, reused afterwards. Pass `--project ""` for a plain top-level chat. Also `CHATGPT_IMAGEGEN_PROJECT`. Failures degrade to a plain chat with a warning, never block the run. |
-| `--keep-tab` | off | *(web)* Leave the ChatGPT tab open after generating (default closes it). |
-| `--web-model` | `Instant` | *(web)* Composer model/effort selected before generating, matched by exact picker label. The **`Pro`** tier has no native image generator (it answers image requests by writing Python), so the web backend switches off it automatically. Pass `""` to keep whatever is selected. Also `CHATGPT_IMAGEGEN_WEB_MODEL`. |
+| `--keep-tab` | off | *(web)* Leave the ChatGPT tab open after generating (default closes it). Implies `--keep-conversation`. |
+| `--keep-conversation` | off | *(web)* Keep the ChatGPT conversation after generating. **Default deletes it** so the run leaves no history (filed under the project only transiently). Also `CHATGPT_IMAGEGEN_KEEP_CONVERSATION=1`. |
+| `--web-model` | `Instant,Auto` | *(web)* Comma-separated model/effort candidates; the first one present in the picker is selected before generating. The **`Pro`** tier has no native image generator (it answers image requests by writing Python), so the web backend switches off it automatically. Pass `""` to keep whatever is selected. Also `CHATGPT_IMAGEGEN_WEB_MODEL`. |
 | `-i`, `--ref PATH_OR_URL` | — | **Image-to-image.** Reference image to edit (repeatable for multiple references). A local path or `http(s)` URL. When given, the model edits the reference(s) instead of rendering from text. Works on **both** backends. See [Image-to-image](#image-to-image). |
 | `-o`, `--out PATH` | `assets/generated/<slug>.<ext>` | Output file; parent dirs created. A warning is printed when the suffix and `--format` disagree (e.g. `-o foo.jpg --format png`). |
 | `--size` | `auto` | `auto` or any `WIDTHxHEIGHT`. Verified working: `1024x1024`, `1024x1536`, `1536x1024`. Larger sizes are forwarded as-is. |
@@ -116,7 +117,7 @@ chatgpt-imagegen "<prompt>" [options]
 | `--stall-timeout` | `120` | Max seconds of silence (no data from backend) before declaring a **stall** — caught well before the total budget. Clamped to `--timeout`. |
 | `--quiet` | off | Print **only** the saved path on stdout (perfect for agent pipelines). Progress still streams to stderr — use `--no-progress` to silence it. |
 | `--no-progress` | off | Suppress the stderr progress timeline (errors still print). |
-| `-V`, `--version` | — | Print the CLI version (`chatgpt-imagegen 0.9.0`) and exit. |
+| `-V`, `--version` | — | Print the CLI version (`chatgpt-imagegen 0.10.0`) and exit. |
 
 Examples:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,7 +36,7 @@ OpenAI 的图像生成有两条完全独立的路:
 
 | 后端 | 怎么生成 | 花哪个桶 | 前置条件 |
 | --- | --- | --- | --- |
-| **`web`** | 驱动你**已登录的 ChatGPT 浏览器**(经 [`chrome-use`](https://github.com/leeguooooo/chrome-use),原名 `agent-browser-stealth`),在普通对话里出图 —— 跟你在 app 里打字出图是同一个界面。靠真 Chrome 连接过掉 Cloudflare + sentinel 工作量证明(无头/普通客户端过不了)。每次的对话自动归档进一个 ChatGPT **项目**(默认 `imagegen`,首次自动创建),不再刷屏历史列表。 | **ChatGPT 对话** —— **不**占用计量的 **Codex 用量**额度。 | 任意登录了 chatgpt.com 的浏览器(**免费档也行**)+ `chrome-use`。 |
+| **`web`** | 驱动你**已登录的 ChatGPT 浏览器**(经 [`chrome-use`](https://github.com/leeguooooo/chrome-use),原名 `agent-browser-stealth`),在普通对话里出图 —— 跟你在 app 里打字出图是同一个界面。靠真 Chrome 连接产出 **Cloudflare Turnstile** token(裸客户端伪造不出来——CF 边缘和 sentinel PoW 都能裸过,Turnstile 才是墙)。每次出图归进一个 ChatGPT **项目**(默认 `imagegen`),且**默认出图后删除该对话**(`--keep-conversation` 可保留),不留历史。 | **ChatGPT 对话** —— **不**占用计量的 **Codex 用量**额度。 | 任意登录了 chatgpt.com 的浏览器(**免费档也行**)+ `chrome-use`。 |
 | **`codex`** | 无头 POST 到 `backend-api/codex/responses`,复用 `~/.codex/auth.json`。 | **Codex 用量**(计量的那个桶)。 | `codex login`。 |
 
 **默认 `auto`**:先试 `web`(省 Codex 用量),没有可用登录浏览器时回退 `codex`。用 `--backend web` / `--backend codex` 强制其一(或环境变量 `CHATGPT_IMAGEGEN_BACKEND`)。
@@ -101,9 +101,10 @@ chatgpt-imagegen "<prompt>" [options]
 | --- | --- | --- |
 | `--backend` | `auto` | `auto` \| `web` \| `codex`。`auto` 优先 web(省 Codex 用量),没有登录浏览器时回退 codex。见[两个后端](#两个后端)。也可用 `CHATGPT_IMAGEGEN_BACKEND`。 |
 | `--profile` | `auto` | *(web)* 驱动哪个 Chrome profile。`auto`:你开着的 Chrome 登录了就用它,否则自动换到一个登录了的(离线探测)。`relay`:只用你开着的 Chrome。或写 profile 名如 `"Profile 3"`。 |
-| `--session` | `imagegen-<pid>` | *(web)* 跨次运行复用一个命名的 `chrome-use` Chrome 标签组。 |
+| `--session` | `imagegen` | *(web)* 跨次运行复用的 `chrome-use` Chrome 标签组名(一个稳定 daemon,而非每次跑都新起一个)。当 web 并发被调到 1 以上时回落为 `imagegen-<pid>`,以隔离并行运行。 |
 | `--project` | `imagegen` | *(web)* 对话归档到哪个 ChatGPT 项目 —— 按名字精确匹配,**没有就自动创建**,有就直接复用。传 `--project ""` 用普通顶层对话。也可用 `CHATGPT_IMAGEGEN_PROJECT`。项目步骤失败只降级为普通对话并告警,绝不阻塞出图。 |
-| `--keep-tab` | 关 | *(web)* 出图后保留 ChatGPT 标签页(默认关闭它)。 |
+| `--keep-tab` | 关 | *(web)* 出图后保留 ChatGPT 标签页(默认关闭它)。隐含 `--keep-conversation`。 |
+| `--keep-conversation` | 关 | *(web)* 出图后保留 ChatGPT 对话。**默认会删除对话**,不留历史记录(只是临时归进 project)。也可经 `CHATGPT_IMAGEGEN_KEEP_CONVERSATION=1` 设置。 |
 | `-o`, `--out PATH` | `assets/generated/<slug>.<ext>` | 输出文件;父目录自动创建。后缀与 `--format` 不一致时会告警(如 `-o foo.jpg --format png`)。 |
 | `--size` | `auto` | `auto` 或任意 `WIDTHxHEIGHT`。已验证:`1024x1024`、`1024x1536`、`1536x1024`。更大尺寸原样透传。 |
 | `--format` | `png` | `png` \| `jpeg` \| `webp` |
@@ -215,7 +216,7 @@ chatgpt-imagegen --backend web
        (签名的 estuary/content URL 由浏览器自己的 cookie 授权)
 ```
 
-token 不出浏览器。每次的对话落在 `imagegen` 项目里(自动创建),不再堆在顶层历史;传 `--project ""` 可退回旧行为。
+token 不出浏览器。每次出图落在 `imagegen` 项目里(自动创建),且**默认出图后删除该对话**不留历史(`--keep-conversation` 可保留);传 `--project ""` 可退回旧行为。
 
 ### `codex` 后端
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,7 +91,8 @@ Useful flags:
 | `--profile auto` \| `relay` \| `NAME` | (web) Which Chrome profile to drive. `auto` (default): use the open Chrome if it's logged in, else auto-switch to a profile that is (detected offline from the cookie DB, read-only). `relay`: only the open Chrome. `"Profile 3"`: that profile. Note: *logged in* ≠ *able to generate* — a free-tier account can still hit its daily image cap. |
 | `--session NAME` | (web) Reuse a named Chrome tab group across runs instead of `imagegen-<pid>`. |
 | `--project NAME` | (web) ChatGPT Project to file the run's conversation under — matched by exact name, **created automatically if absent**, reused if present. Default `imagegen` (or `CHATGPT_IMAGEGEN_PROJECT`). Pass `--project ""` for a plain top-level chat. If the project step fails, the run warns and continues in a plain chat — it never blocks generation. |
-| `--keep-tab` | (web) Leave the ChatGPT tab open after generating (default closes it). Useful for debugging. |
+| `--keep-tab` | (web) Leave the ChatGPT tab open after generating (default closes it). Useful for debugging. Implies `--keep-conversation`. |
+| `--keep-conversation` | (web) Keep the ChatGPT conversation after generating. **Default deletes it** (`PATCH is_visible:false`) so the run leaves no history — it's filed under the project only transiently. Also `CHATGPT_IMAGEGEN_KEEP_CONVERSATION=1`. |
 | `-o PATH` | Always use when you know where the file should go in the repo. |
 | `--size 1024x1024` | Square icons / logos (verified) |
 | `--size 1536x1024` | Landscape hero banners, social cards (verified) |

--- a/chatgpt-imagegen
+++ b/chatgpt-imagegen
@@ -52,7 +52,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 CODEX_BACKEND = "https://chatgpt.com/backend-api/codex/responses"
 
@@ -1073,6 +1073,50 @@ def _enter_project(ab: str, session: str, name: str, remaining, emit) -> None:
                 pass
 
 
+# JS: delete (hide) the conversation currently open in the tab. ChatGPT's own
+# "delete" is a PATCH with `is_visible:false` — it drops the chat from history,
+# search, and the sidebar. Conversation id comes from the `/c/<id>` URL segment
+# (works for both plain `/c/…` and project `/g/g-p-…/c/…` URLs). accessToken is
+# read from the in-page session, same as _JS_ENSURE_PROJECT.
+_JS_DELETE_CONV = r"""(async () => {
+  try {
+    const m = location.pathname.match(/\/c\/([0-9a-f-]{16,})/i);
+    if (!m) return JSON.stringify({ok: false, error: 'no conversation id in URL'});
+    const id = m[1];
+    const sess = await fetch('/api/auth/session', {credentials: 'include'})
+      .then(r => r.json()).catch(() => null);
+    if (!sess || !sess.accessToken)
+      return JSON.stringify({ok: false, error: 'no accessToken in /api/auth/session'});
+    const r = await fetch('/backend-api/conversation/' + id, {
+      method: 'PATCH', credentials: 'include',
+      headers: {Authorization: 'Bearer ' + sess.accessToken,
+                'Content-Type': 'application/json'},
+      body: JSON.stringify({is_visible: false})});
+    if (!r.ok) return JSON.stringify({ok: false, error: 'delete HTTP ' + r.status});
+    return JSON.stringify({ok: true, id});
+  } catch (e) { return JSON.stringify({ok: false, error: String(e)}); }
+})()"""
+
+
+def _delete_conversation(ab, session, remaining, emit) -> None:
+    """Delete the conversation just used so the run leaves no history.
+
+    Best-effort: the image is already saved by the time we get here, so a delete
+    failure only warns — it never fails the run or loses the image.
+    """
+    try:
+        res = _ab_eval(ab, _JS_DELETE_CONV, session=session,
+                       timeout=min(20.0, remaining()))
+    except GatewayError as e:
+        emit(f"warning: could not delete conversation ({e}); it stays in history")
+        return
+    if isinstance(res, dict) and res.get("ok"):
+        emit("conversation deleted (no history kept)")
+    else:
+        detail = res.get("error") if isinstance(res, dict) else res
+        emit(f"warning: could not delete conversation ({detail}); it stays in history")
+
+
 # JS: locate the composer model-picker button and return its label + viewport
 # center {text, x, y}, or null. The picker has no stable selector, so match the
 # one menu-opening button whose short label names a model/effort.
@@ -1163,6 +1207,11 @@ def _ensure_web_model(ab, session, model_label, remaining, emit) -> None:
         raise
     except GatewayError as e:
         emit(f"warning: could not switch model ({e}); using the current one")
+
+
+def _env_bool(name: str) -> bool:
+    """True if env var ``name`` is set to a truthy value (1/true/yes/on)."""
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
 
 
 def _backend_limit(kind: str, default: int) -> int:
@@ -1341,8 +1390,14 @@ def run_web(
             ab, session,
             getattr(args, "web_model", WEB_MODEL_DEFAULT) or WEB_MODEL_DEFAULT,
             remaining, emit)
-        return _generate_in_browser(
+        result = _generate_in_browser(
             ab, session, user_text, args, deadline, remaining, emit, refs=refs)
+        # Image is saved by now. Delete the conversation so no history is left —
+        # the default. `--keep-conversation` opts out; `--keep-tab` (debugging)
+        # implies keeping it, since an open tab on a deleted chat is useless.
+        if not getattr(args, "keep_conversation", False) and not args.keep_tab:
+            _delete_conversation(ab, session, remaining, emit)
+        return result
     finally:
         if not args.keep_tab:
             _close()
@@ -1856,7 +1911,17 @@ def main() -> int:
         "--keep-tab",
         action="store_true",
         help="(web backend) leave the ChatGPT tab open after generating instead "
-             "of closing it.",
+             "of closing it. Implies --keep-conversation (an open tab on a "
+             "deleted chat is useless).",
+    )
+    parser.add_argument(
+        "--keep-conversation",
+        action="store_true",
+        default=_env_bool("CHATGPT_IMAGEGEN_KEEP_CONVERSATION"),
+        help="(web backend) keep the ChatGPT conversation after generating. "
+             "Default: the conversation is DELETED so the run leaves no history "
+             "(it's filed under the project only transiently). Also settable via "
+             "CHATGPT_IMAGEGEN_KEEP_CONVERSATION=1.",
     )
     parser.add_argument(
         "--timeout",


### PR DESCRIPTION
出图后默认删除对话，不留历史记录。

- 生成并下载完成后，默认删除该 ChatGPT 对话（`PATCH /backend-api/conversation/<id>` body `{is_visible:false}`，即网页删除会话用的接口）。会话 id 取自页面 `/c/<id>` URL（兼容 `/c/…` 和项目 `/g/g-p-…/c/…`）。**best-effort**：图已存好，删除失败只告警不阻断。
- `--keep-conversation`（+ `CHATGPT_IMAGEGEN_KEEP_CONVERSATION=1`）保留对话；`--keep-tab`（调试）隐含保留——开着的标签指向已删对话没意义。
- 顺手修正前序 PR 带出的旧文档：`--session` 默认（稳定 `imagegen`）、`--web-model` 默认（`Instant,Auto`）、backends 表 Cloudflare→Turnstile。版本 0.9.0 → 0.10.0。

**验证**：真实 web 跑打印 `conversation deleted (no history kept)`，且事后查 project 会话列表确认刚生成的会话已不在历史中。20 个单测仍全过。
