### PR TITLE
ci: GitHub Actions（py_compile + unittest，Python 3.10–3.13）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      # The CLI is stdlib-only — no install step, nothing to pip.
+      - name: Byte-compile the CLI
+        run: python -m py_compile chatgpt-imagegen
+      - name: Run unit tests
+        run: python -m unittest test_chatgpt_imagegen -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # chatgpt-imagegen
 
+[![CI](https://github.com/leeguooooo/chatgpt-imagegen/actions/workflows/ci.yml/badge.svg)](https://github.com/leeguooooo/chatgpt-imagegen/actions/workflows/ci.yml)
+
 **English** | [中文](./README.zh-CN.md)
 
 **Generate images using your ChatGPT subscription — no `OPENAI_API_KEY` needed.**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,7 @@
 # chatgpt-imagegen
 
+[![CI](https://github.com/leeguooooo/chatgpt-imagegen/actions/workflows/ci.yml/badge.svg)](https://github.com/leeguooooo/chatgpt-imagegen/actions/workflows/ci.yml)
+
 [English](./README.md) | **中文**
 
 **用你的 ChatGPT 订阅生成图片 —— 不需要 `OPENAI_API_KEY`。**


### PR DESCRIPTION
给这条快速迭代的主线兜底：每次 push / PR 自动 `py_compile` + 跑 20 个单测。

- 工程是 stdlib-only，CI 无 pip 安装步骤；矩阵覆盖 Python 3.10–3.13。
- 测试无网络/无浏览器依赖（`_download_ref_url` 用 mock），CI 跑得干净。
- README 加 CI 徽章。
