### PR TITLE
fix(gemini): 走 blob 直下保住 C2PA 溯源信息，canvas 降级为兜底

### DIFF
--- a/chatgpt-imagegen
+++ b/chatgpt-imagegen
@@ -2385,8 +2385,46 @@ def _gemini_poll(ab, session, baseline, deadline, remaining, emit) -> str:
                        f"(last phase: {phase or 'connecting'})")
 
 
+def _gemini_blob_download(ab, session, src, remaining) -> tuple[bytes, JsonDict] | None:
+    """Pull a blob: src byte-exact via `chrome-use download-url`, or None.
+
+    This is the route that preserves Google's signed C2PA provenance manifest
+    (issue #27). chrome-use used to reject blob: URLs outright
+    (leeguooooo/chrome-use#169), which left only the canvas re-encode below —
+    and a canvas holds pixels, not files, so every metadata block died with it.
+    Upstream now resolves the blob inside the page and streams the original
+    bytes out, so the manifest survives.
+
+    Returns None (never raises) on any failure — an old chrome-use, a dead
+    blob, a >32MB payload. The caller falls back to the canvas, which always
+    worked; losing provenance beats losing the image.
+    """
+    if not src.startswith("blob:"):
+        return None
+    tmpdir = tempfile.mkdtemp(prefix="imagegen-gemini-")
+    dest = Path(tmpdir) / "out.bin"
+    try:
+        _ab(ab, "download-url", src, str(dest),
+            session=session, timeout=min(60.0, remaining()))
+        data = dest.read_bytes()
+    except (GatewayError, OSError):
+        return None
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    ctype = _sniff_mime(data[:16])
+    if not data or not ctype:
+        return None  # not an image — treat as a miss, let the canvas try
+    return data, {"content_type": ctype, "source": "gemini",
+                  "transport": "blob-download", "provenance": "preserved"}
+
+
 def _gemini_fetch(ab, session, src, remaining, emit) -> tuple[bytes, JsonDict]:
     emit("downloading image bytes")
+    got = _gemini_blob_download(ab, session, src, remaining)
+    if got is not None:
+        emit(f"read {len(got[0])} bytes byte-exact off the blob "
+             f"(C2PA provenance intact)")
+        return got
     last = None
     for _ in range(5):
         try:
@@ -2401,7 +2439,8 @@ def _gemini_fetch(ab, session, src, remaining, emit) -> tuple[bytes, JsonDict]:
                 raise GatewayError(
                     "generated image came back as invalid base64") from None
             return data, {"content_type": "image/png", "source": "gemini",
-                          "width": res.get("w"), "height": res.get("h")}
+                          "width": res.get("w"), "height": res.get("h"),
+                          "transport": "canvas", "provenance": "stripped"}
         last = res
         time.sleep(2.0)  # nearly always just "img not decoded yet"
     raise GatewayError(f"failed to read the generated image off the page: {last}")
@@ -2513,9 +2552,12 @@ def run_gemini(
         _gemini_submit(ab, session, chosen_composer, text, remaining, emit)
         src = _gemini_poll(ab, session, baseline, deadline, remaining, emit)
         data, meta = _gemini_fetch(ab, session, src, remaining, emit)
-        emit("note: the PNG is re-encoded off a canvas, which drops Google's "
-             "C2PA provenance manifest (the imperceptible SynthID watermark "
-             "in the pixels is unaffected)")
+        if meta.get("provenance") == "stripped":
+            emit("note: the blob could not be downloaded byte-exact, so the "
+                 "PNG was re-encoded off a canvas — that drops Google's C2PA "
+                 "provenance manifest (the imperceptible SynthID watermark in "
+                 "the pixels is unaffected). Upgrading chrome-use usually "
+                 "restores the byte-exact path")
         if not refs:
             emit("note: text-to-image results carry a visible Gemini watermark "
                  "at the bottom-right")

--- a/test_chatgpt_imagegen.py
+++ b/test_chatgpt_imagegen.py
@@ -2068,5 +2068,55 @@ class ContentTypeMismatch(unittest.TestCase):
         self.assertIn("_default_out_path(args.prompt, _actual_fmt)", src)
 
 
+class GeminiBlobDownload(unittest.TestCase):
+    """issue #27 — prefer the byte-exact blob route so Google's C2PA
+    provenance manifest survives; fall back to the canvas, never fail."""
+
+    def test_non_blob_src_is_not_attempted(self):
+        self.assertIsNone(cig._gemini_blob_download(
+            "chrome-use", "s", "https://x/y.png", lambda: 30.0))
+
+    def test_blob_bytes_are_returned_with_the_sniffed_type(self):
+        png = (b"\x89PNG\r\n\x1a\n" + b"\x00" * 24)
+
+        def fake_ab(ab, *a, **kw):
+            self.assertEqual(a[0], "download-url")
+            Path(a[2]).write_bytes(png)
+            return ""
+
+        with unittest.mock.patch.object(cig, "_ab", fake_ab):
+            data, meta = cig._gemini_blob_download(
+                "chrome-use", "s", "blob:https://gemini.google.com/x",
+                lambda: 30.0)
+        self.assertEqual(data, png)
+        self.assertEqual(meta["content_type"], "image/png")
+        self.assertEqual(meta["provenance"], "preserved")
+
+    def test_old_chrome_use_falls_back_instead_of_raising(self):
+        def boom(*a, **kw):
+            raise cig.GatewayError("Invalid download URL: expected http://")
+
+        with unittest.mock.patch.object(cig, "_ab", boom):
+            self.assertIsNone(cig._gemini_blob_download(
+                "chrome-use", "s", "blob:https://gemini.google.com/x",
+                lambda: 30.0))
+
+    def test_non_image_payload_is_treated_as_a_miss(self):
+        def fake_ab(ab, *a, **kw):
+            Path(a[2]).write_bytes(b"<html>nope</html>")
+            return ""
+
+        with unittest.mock.patch.object(cig, "_ab", fake_ab):
+            self.assertIsNone(cig._gemini_blob_download(
+                "chrome-use", "s", "blob:https://gemini.google.com/x",
+                lambda: 30.0))
+
+    def test_canvas_path_still_labels_itself_as_provenance_stripped(self):
+        src = Path(cig.__file__).read_text()
+        self.assertIn('"transport": "canvas", "provenance": "stripped"', src)
+        # The C2PA warning must not fire on the byte-exact path.
+        self.assertIn('if meta.get("provenance") == "stripped":', src)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
修 #27。

## 背景

上游 leeguooooo/chrome-use#169（blob: URL 被 `download-url` 直接拒绝）**已经修好了**，本机 chrome-use 1.5.89 已带该能力：

```
blob: URLs take a different route. Chrome's download machinery can't reach a
blob ... so the bytes are read from inside the page and written straight to
disk — byte-exact, metadata intact, no ab-connect needed.
```

所以 #27 里「只能 canvas 重编码，因此丢 C2PA」这个前提不再成立。

## 改动

`_gemini_fetch` 现在先试 `_gemini_blob_download`（`chrome-use download-url <blob> <path>`），拿到的是原始字节，Google 签名的 C2PA 溯源清单原样保留。

失败一律**静默回退到原来的 canvas 路径**，不抛异常——老版 chrome-use、blob 已失效、超过 32MB 上限、下回来的不是图片，这些情况下丢溯源信息也好过丢图。

meta 里新增 `transport`（`blob-download` / `canvas`）与 `provenance`（`preserved` / `stripped`），那条 C2PA 告警改成只在真走了 canvas 时才打印，并提示升级 chrome-use 通常能恢复字节精确路径。

## 验证

- 在 example.com 页面里人工构造一个 blob（PNG magic + 一段任意尾部载荷），跑 `chrome-use download-url` 落盘，`xxd` 比对**字节完全一致**。**不消耗任何出图配额。**
- 单元测试 +5：非 blob 不尝试、成功路径按嗅探类型返回、老版 chrome-use 报错时回退而不抛、非图片载荷视为未命中、canvas 路径仍标记 provenance=stripped。
- 全量 211 个测试通过。

**未做**：真实 Gemini 出图的端到端验证（需要烧配额）。合并前建议本地手跑一次 `--backend gemini`，确认输出文件里 C2PA 清单确实在。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gemini image downloads now preserve provenance metadata when byte-exact retrieval is available.
  * Added automatic fallback to PNG extraction when direct retrieval isn’t supported.

* **Bug Fixes**
  * Improved handling of unsupported retrieval methods and non-image responses.
  * Fallback warnings now explain that provenance metadata may be removed and recommend upgrading `chrome-use`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->