### PR TITLE
fix(windows): make fcntl import optional so the CLI runs on Windows

### DIFF
--- a/chatgpt-imagegen
+++ b/chatgpt-imagegen
@@ -35,7 +35,10 @@ from __future__ import annotations
 
 import argparse
 import base64
-import fcntl
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl; the cross-process flock gate
+    fcntl = None      # degrades to a no-op there (see _concurrency_slot).
 import hashlib
 import http.server
 import json
@@ -1481,7 +1484,10 @@ def _concurrency_slot(kind: str, limit: int, progress: bool, start: float) -> "I
     kernel releases a slot when its holder dies, so a crash can't wedge the
     queue. ``limit <= 0`` disables the gate entirely.
     """
-    if limit <= 0:
+    if limit <= 0 or fcntl is None:
+        # No POSIX flock on this platform (e.g. Windows): skip the
+        # cross-process gate rather than crash. Single manual runs are
+        # unaffected; concurrent-fanout callers should self-limit there.
         yield
         return
     base = tempfile.gettempdir()


### PR DESCRIPTION
`chatgpt-imagegen` imports `fcntl` at module top level, which does not exist on Windows — the CLI fails at import time before doing anything.

This makes the import optional and degrades the cross-process concurrency gate to a no-op when `fcntl` is unavailable:

- `import fcntl` wrapped in `try/except ImportError`, setting `fcntl = None`
- `_concurrency_slot()` skips the flock gate when `fcntl is None`, same path as `limit <= 0`

POSIX behaviour is unchanged. On Windows, single manual runs work as expected; callers doing concurrent fan-out need to self-limit, which is noted in the inline comment.

8 added / 2 removed, single file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility by allowing image generation to run on systems where the optional file-locking capability is unavailable.
  * Prevented execution failures on platforms such as Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->